### PR TITLE
chore: hide Kakao login button

### DIFF
--- a/frontend/src/layouts/MainLayout.jsx
+++ b/frontend/src/layouts/MainLayout.jsx
@@ -1,25 +1,14 @@
 import { useState } from 'react';
-import { Outlet, Link, useNavigate } from 'react-router-dom';
+import { Outlet, Link } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { Button } from '@/components/ui/button';
 import { Menu, X } from 'lucide-react';
 
 export default function MainLayout() {
-  const { currentUser, kakaoLogin, logout } = useAuth();
+  const { currentUser, logout } = useAuth();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const navigate = useNavigate();
 
   const closeMenu = () => setIsMenuOpen(false);
-
-  const handleLogin = async () => {
-    try {
-      await kakaoLogin();
-      navigate('/dashboard');
-      closeMenu();
-    } catch (error) {
-      alert('로그인에 실패했습니다.');
-    }
-  };
 
   return (
     <div>
@@ -32,9 +21,7 @@ export default function MainLayout() {
             <Link to="/community" className="text-gray-600 hover:text-brand-green">커뮤니티</Link>
             {currentUser ? (
               <Button variant="secondary" onClick={logout}>로그아웃</Button>
-            ) : (
-              <Button onClick={handleLogin}>카카오 로그인</Button>
-            )}
+            ) : null}
           </div>
           <button
             className="md:hidden text-gray-600"
@@ -102,11 +89,7 @@ export default function MainLayout() {
             >
               로그아웃
             </Button>
-          ) : (
-            <Button className="mt-4 w-full" onClick={handleLogin}>
-              카카오 로그인
-            </Button>
-          )}
+          ) : null}
         </div>
       </div>
 

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -1,4 +1,4 @@
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { Button } from '@/components/ui/button';
 import { ShieldCheck, CalendarDays, BarChart2, Users } from 'lucide-react';
@@ -13,17 +13,7 @@ const FeatureCard = ({ icon, title, description }) => (
 );
 
 export default function HomePage() {
-  const { currentUser, kakaoLogin, logout, loading } = useAuth();
-  const navigate = useNavigate();
-
-  const handleLogin = async () => {
-    try {
-      await kakaoLogin();
-      navigate('/dashboard');
-    } catch (error) {
-      alert('로그인에 실패했습니다. 팝업 차단을 해제하고 다시 시도해주세요.');
-    }
-  };
+  const { currentUser, logout, loading } = useAuth();
   
   return (
     <div className="bg-gray-50">
@@ -38,9 +28,7 @@ export default function HomePage() {
             
             {loading ? <Loader2 className="w-5 h-5 animate-spin" /> : currentUser ? (
               <Button variant="secondary" onClick={logout}>로그아웃</Button>
-            ) : (
-              <Button onClick={handleLogin}>카카오 로그인</Button>
-            )}
+            ) : null}
           </div>
         </nav>
       </header>

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,14 +1,10 @@
 import { useAuth } from '../contexts/AuthContext';
 import { useNavigate, Link } from 'react-router-dom';
-import { Button } from '@/components/ui/button';
-import { useState, useEffect } from 'react';
-import { Loader2 } from 'lucide-react';
+import { useEffect } from 'react';
 
 export default function LoginPage() {
-  const { kakaoLogin, currentUser } = useAuth();
+  const { currentUser } = useAuth();
   const navigate = useNavigate();
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState('');
 
   // 이미 로그인 되어 있다면 대시보드로 리다이렉트
   useEffect(() => {
@@ -17,32 +13,11 @@ export default function LoginPage() {
     }
   }, [currentUser, navigate]);
 
-  const handleLogin = async () => {
-    setIsLoading(true);
-    setError('');
-    try {
-      await kakaoLogin();
-      navigate('/dashboard');
-    } catch (err) {
-      console.error(err);
-      setError('로그인에 실패했습니다. 팝업 차단을 해제하고 다시 시도해주세요.');
-      setIsLoading(false);
-    }
-  };
-
   return (
     <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100 p-4">
       <div className="p-8 bg-white rounded-lg shadow-md text-center w-full max-w-sm">
         <Link to="/" className="text-3xl font-bold text-brand-green mb-2 inline-block">축구의 모든것</Link>
-        <p className="text-gray-600 mb-8">학부모님, 환영합니다!</p>
-        
-        {/* public 폴더에 kakao_login.png 같은 이미지를 넣고 사용 */}
-        <button onClick={handleLogin} disabled={isLoading} className="w-full">
-            <img src="/kakao_login_medium_wide.png" alt="카카오 로그인" className="w-full" />
-        </button>
-
-        {isLoading && <Loader2 className="mx-auto mt-4 h-6 w-6 animate-spin" />}
-        {error && <p className="text-red-500 text-sm mt-4">{error}</p>}
+        <p className="text-gray-600 mb-8">로그인 기능이 일시적으로 비활성화되었습니다.</p>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- hide Kakao login options in main layout and home header
- replace Kakao login page with temporary disable notice

## Testing
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm test` (backend) *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6893f7fefb2083238f79acc2ed4f17e8