### PR TITLE
feat: add mobile navigation menu

### DIFF
--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -1,7 +1,8 @@
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { Button } from '@/components/ui/button';
-import { ShieldCheck, CalendarDays, BarChart2, Users } from 'lucide-react';
+import { ShieldCheck, CalendarDays, BarChart2, Users, Menu, X } from 'lucide-react';
 import { Loader2 } from 'lucide-react';
 
 const FeatureCard = ({ icon, title, description }) => (
@@ -14,24 +15,75 @@ const FeatureCard = ({ icon, title, description }) => (
 
 export default function HomePage() {
   const { currentUser, logout, loading } = useAuth();
-  
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  const closeMenu = () => setIsMenuOpen(false);
+
   return (
     <div className="bg-gray-50">
       <header className="bg-white shadow-sm sticky top-0 z-50">
         <nav className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 h-20 flex items-center justify-between">
           <Link to="/" className="text-2xl font-bold text-brand-green">축구의 모든것</Link>
-          <div className="flex items-center space-x-4">
-            <Link to="/dashboard" className="text-gray-600 hover:text-brand-green hidden sm:block">대시보드</Link>
-            <Link to="/schedule" className="text-gray-600 hover:text-brand-green hidden sm:block">훈련 일정</Link>
-            <Link to="/community" className="text-gray-600 hover:text-brand-green hidden sm:block">커뮤니티</Link>
-            <Link to="/admin" className="text-gray-600 hover:text-brand-green hidden sm:block">관리자</Link>
-            
+          <div className="hidden sm:flex items-center space-x-4">
+            <Link to="/dashboard" className="text-gray-600 hover:text-brand-green">대시보드</Link>
+            <Link to="/schedule" className="text-gray-600 hover:text-brand-green">훈련 일정</Link>
+            <Link to="/community" className="text-gray-600 hover:text-brand-green">커뮤니티</Link>
+            <Link to="/admin" className="text-gray-600 hover:text-brand-green">관리자</Link>
+
             {loading ? <Loader2 className="w-5 h-5 animate-spin" /> : currentUser ? (
               <Button variant="secondary" onClick={logout}>로그아웃</Button>
             ) : null}
           </div>
+          <button
+            className="sm:hidden text-gray-600"
+            onClick={() => setIsMenuOpen(true)}
+            aria-label="Open menu"
+          >
+            <Menu className="w-6 h-6" />
+          </button>
         </nav>
       </header>
+
+      {/* Mobile menu */}
+      <div className={`fixed inset-0 z-40 ${isMenuOpen ? '' : 'pointer-events-none'}`}>
+        <div
+          className={`absolute inset-0 bg-black transition-opacity duration-300 ${
+            isMenuOpen ? 'opacity-50' : 'opacity-0'
+          }`}
+          onClick={closeMenu}
+        />
+        <div
+          className={`fixed inset-y-0 left-0 w-64 bg-white shadow-md transform transition-transform duration-300 p-6 flex flex-col ${
+            isMenuOpen ? 'translate-x-0' : '-translate-x-full'
+          }`}
+        >
+          <button
+            className="mb-4 text-gray-600"
+            onClick={closeMenu}
+            aria-label="Close menu"
+          >
+            <X className="w-6 h-6" />
+          </button>
+          <nav className="flex flex-col space-y-4 flex-1">
+            <Link to="/dashboard" className="text-gray-600 hover:text-brand-green" onClick={closeMenu}>대시보드</Link>
+            <Link to="/schedule" className="text-gray-600 hover:text-brand-green" onClick={closeMenu}>훈련 일정</Link>
+            <Link to="/community" className="text-gray-600 hover:text-brand-green" onClick={closeMenu}>커뮤니티</Link>
+            <Link to="/admin" className="text-gray-600 hover:text-brand-green" onClick={closeMenu}>관리자</Link>
+          </nav>
+          {currentUser ? (
+            <Button
+              variant="secondary"
+              className="mt-4 w-full"
+              onClick={() => {
+                logout();
+                closeMenu();
+              }}
+            >
+              로그아웃
+            </Button>
+          ) : null}
+        </div>
+      </div>
 
       <main>
         <section className="bg-brand-green text-white text-center py-20">


### PR DESCRIPTION
## Summary
- add a responsive hamburger menu to the home page header
- include slide-in mobile navigation with logout option

## Testing
- `cd frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689431aa200c8323904d3bf3e642ea03