### PR TITLE
feat: enable parent login and add signup flow

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import AdminLayout from './layouts/AdminLayout';
 // Public Pages
 import HomePage from './pages/HomePage';
 import LoginPage from './pages/LoginPage';
+import SignupPage from './pages/SignupPage';
 
 // Parent Pages
 import DashboardPage from './pages/DashboardPage';
@@ -25,6 +26,7 @@ export default function App() {
         {/* Public Routes & Parent Routes (테스트용으로 제한 해제된 상태) */}
         <Route path="/" element={<HomePage />} />
         <Route path="/login" element={<LoginPage />} />
+        <Route path="/signup" element={<SignupPage />} />
 
         <Route element={<MainLayout />}>
           <Route path="/dashboard" element={<DashboardPage />} />

--- a/frontend/src/firebaseConfig.js
+++ b/frontend/src/firebaseConfig.js
@@ -1,12 +1,21 @@
 import { initializeApp } from "firebase/app";
-import { getAuth, signInWithCustomToken, signOut, onAuthStateChanged } from 'firebase/auth';
+import {
+  getAuth,
+  signInWithCustomToken,
+  signOut,
+  onAuthStateChanged,
+  createUserWithEmailAndPassword,
+  signInWithEmailAndPassword,
+  fetchSignInMethodsForEmail,
+} from 'firebase/auth';
 // ⭐️ 1. 필요한 모든 Firestore 함수들을 여기서 import 합니다.
-import { 
-  getFirestore, 
-  collection, 
-  doc, 
-  getDoc, 
-  setDoc, 
+import {
+  getFirestore,
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  setDoc,
   serverTimestamp,
   query,
   where,
@@ -15,7 +24,7 @@ import {
   limit,
   addDoc,
   updateDoc,
-  deleteDoc
+  deleteDoc,
 } from 'firebase/firestore';
 import { getStorage } from 'firebase/storage';
 import { getFunctions, httpsCallable } from 'firebase/functions';
@@ -46,16 +55,20 @@ export {
   db, 
   storage, 
   functions,
-  
+
   // Auth 함수들
   signInWithCustomToken,
   signOut,
   onAuthStateChanged,
-  
+  createUserWithEmailAndPassword,
+  signInWithEmailAndPassword,
+  fetchSignInMethodsForEmail,
+
   // ⭐️ 2. 여기서 import한 모든 Firestore 함수들을 export 합니다.
   collection,
   doc,
   getDoc,
+  getDocs,
   setDoc,
   serverTimestamp,
   query,

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -30,9 +30,20 @@ export default function HomePage() {
             <Link to="/community" className="text-gray-600 hover:text-brand-green">커뮤니티</Link>
             <Link to="/admin" className="text-gray-600 hover:text-brand-green">관리자</Link>
 
-            {loading ? <Loader2 className="w-5 h-5 animate-spin" /> : currentUser ? (
+            {loading ? (
+              <Loader2 className="w-5 h-5 animate-spin" />
+            ) : currentUser ? (
               <Button variant="secondary" onClick={logout}>로그아웃</Button>
-            ) : null}
+            ) : (
+              <>
+                <Button asChild>
+                  <Link to="/login">로그인</Link>
+                </Button>
+                <Button variant="outline" asChild>
+                  <Link to="/signup">회원가입</Link>
+                </Button>
+              </>
+            )}
           </div>
           <button
             className="sm:hidden text-gray-600"
@@ -81,7 +92,16 @@ export default function HomePage() {
             >
               로그아웃
             </Button>
-          ) : null}
+          ) : (
+            <div className="mt-4 w-full space-y-2">
+              <Button className="w-full" asChild>
+                <Link to="/login" onClick={closeMenu}>로그인</Link>
+              </Button>
+              <Button className="w-full" variant="outline" asChild>
+                <Link to="/signup" onClick={closeMenu}>회원가입</Link>
+              </Button>
+            </div>
+          )}
         </div>
       </div>
 

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,10 +1,20 @@
 import { useAuth } from '../contexts/AuthContext';
 import { useNavigate, Link } from 'react-router-dom';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Loader2 } from 'lucide-react';
+import { auth, signInWithEmailAndPassword } from '../firebaseConfig';
 
 export default function LoginPage() {
-  const { currentUser } = useAuth();
+  const { currentUser, kakaoLogin } = useAuth();
   const navigate = useNavigate();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [loadingEmail, setLoadingEmail] = useState(false);
+  const [loadingKakao, setLoadingKakao] = useState(false);
+  const [error, setError] = useState(null);
 
   // 이미 로그인 되어 있다면 대시보드로 리다이렉트
   useEffect(() => {
@@ -13,11 +23,74 @@ export default function LoginPage() {
     }
   }, [currentUser, navigate]);
 
+  const handleEmailLogin = async (e) => {
+    e.preventDefault();
+    setError(null);
+    setLoadingEmail(true);
+    try {
+      await signInWithEmailAndPassword(auth, email, password);
+      navigate('/dashboard');
+    } catch (err) {
+      console.error(err);
+      setError('로그인에 실패했습니다. 이메일과 비밀번호를 확인해주세요.');
+    } finally {
+      setLoadingEmail(false);
+    }
+  };
+
+  const handleKakaoLogin = async () => {
+    setError(null);
+    setLoadingKakao(true);
+    try {
+      await kakaoLogin();
+      navigate('/dashboard');
+    } catch (err) {
+      console.error(err);
+      setError('로그인에 실패했습니다. 다시 시도해주세요.');
+    } finally {
+      setLoadingKakao(false);
+    }
+  };
+
   return (
     <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100 p-4">
-      <div className="p-8 bg-white rounded-lg shadow-md text-center w-full max-w-sm">
-        <Link to="/" className="text-3xl font-bold text-brand-green mb-2 inline-block">축구의 모든것</Link>
-        <p className="text-gray-600 mb-8">로그인 기능이 일시적으로 비활성화되었습니다.</p>
+      <div className="p-8 bg-white rounded-lg shadow-md w-full max-w-sm space-y-4">
+        <Link to="/" className="text-3xl font-bold text-brand-green mb-2 inline-block text-center">축구의 모든것</Link>
+        {error && <p className="text-red-500 text-center">{error}</p>}
+        <form onSubmit={handleEmailLogin} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="email">이메일</Label>
+            <Input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="password">비밀번호</Label>
+            <Input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
+          </div>
+          <Button type="submit" className="w-full" disabled={loadingEmail}>
+            {loadingEmail && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            이메일로 로그인
+          </Button>
+        </form>
+        <Button className="w-full" onClick={handleKakaoLogin} disabled={loadingKakao}>
+          {loadingKakao && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          카카오로 로그인
+        </Button>
+        <p className="text-sm text-center">
+          계정이 없으신가요?{' '}
+          <Link to="/signup" className="text-brand-green">회원가입</Link>
+        </p>
       </div>
     </div>
   );

--- a/frontend/src/pages/SignupPage.jsx
+++ b/frontend/src/pages/SignupPage.jsx
@@ -1,0 +1,174 @@
+import { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import {
+  auth,
+  createUserWithEmailAndPassword,
+  fetchSignInMethodsForEmail,
+  db,
+  doc,
+  setDoc,
+  serverTimestamp,
+  collection,
+  query,
+  where,
+  getDocs,
+} from '../firebaseConfig';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import { Loader2 } from 'lucide-react';
+
+export default function SignupPage() {
+  const navigate = useNavigate();
+  const [email, setEmail] = useState('');
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [children, setChildren] = useState([
+    { name: '', gender: '', age: '', grade: '', note: '' },
+  ]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const handleAddChild = () => {
+    setChildren([...children, { name: '', gender: '', age: '', grade: '', note: '' }]);
+  };
+
+  const handleChildChange = (index, field, value) => {
+    const updated = [...children];
+    updated[index][field] = value;
+    setChildren(updated);
+  };
+
+  const handleSignup = async (e) => {
+    e.preventDefault();
+    setError(null);
+    if (password !== confirmPassword) {
+      setError('비밀번호가 일치하지 않습니다.');
+      return;
+    }
+    setLoading(true);
+    try {
+      const methods = await fetchSignInMethodsForEmail(auth, email);
+      if (methods.length > 0) {
+        setError('이미 사용중인 이메일입니다.');
+        setLoading(false);
+        return;
+      }
+      const usernameQuery = query(collection(db, 'users'), where('displayName', '==', username));
+      const usernameSnap = await getDocs(usernameQuery);
+      if (!usernameSnap.empty) {
+        setError('이미 사용중인 아이디입니다.');
+        setLoading(false);
+        return;
+      }
+      const userCredential = await createUserWithEmailAndPassword(auth, email, password);
+      const uid = userCredential.user.uid;
+      const userData = {
+        uid,
+        email,
+        username,
+        displayName: username,
+        role: 'parent',
+        children: children.map((c) => ({
+          name: c.name,
+          gender: c.gender,
+          age: c.age,
+          grade: c.grade,
+          note: c.note,
+        })),
+        createdAt: serverTimestamp(),
+      };
+      await setDoc(doc(db, 'users', uid), userData);
+      navigate('/dashboard');
+    } catch (err) {
+      console.error(err);
+      setError('회원가입에 실패했습니다. 다시 시도해주세요.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100 p-4">
+      <form onSubmit={handleSignup} className="p-8 bg-white rounded-lg shadow-md w-full max-w-md space-y-4">
+        <Link to="/" className="text-3xl font-bold text-brand-green mb-6 inline-block">축구의 모든것</Link>
+        {error && <p className="text-red-500">{error}</p>}
+        <div className="space-y-2">
+          <Label htmlFor="email">이메일</Label>
+          <Input id="email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="username">아이디</Label>
+          <Input id="username" value={username} onChange={(e) => setUsername(e.target.value)} required />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="password">비밀번호</Label>
+          <Input id="password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} required />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="confirmPassword">비밀번호 확인</Label>
+          <Input
+            id="confirmPassword"
+            type="password"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            required
+          />
+        </div>
+        <div className="space-y-2">
+          <Label>자녀 정보</Label>
+          {children.map((child, idx) => (
+            <div key={idx} className="border p-4 rounded-md space-y-2">
+              <div className="space-y-2">
+                <Label htmlFor={`child-name-${idx}`}>이름</Label>
+                <Input id={`child-name-${idx}`} value={child.name} onChange={(e) => handleChildChange(idx, 'name', e.target.value)} required />
+              </div>
+              <div className="space-y-2">
+                <Label>성별</Label>
+                <Select value={child.gender} onValueChange={(val) => handleChildChange(idx, 'gender', val)}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="성별 선택" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="male">남</SelectItem>
+                    <SelectItem value="female">여</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor={`child-age-${idx}`}>연령</Label>
+                <Input id={`child-age-${idx}`} type="number" value={child.age} onChange={(e) => handleChildChange(idx, 'age', e.target.value)} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor={`child-grade-${idx}`}>학년</Label>
+                <Input id={`child-grade-${idx}`} value={child.grade} onChange={(e) => handleChildChange(idx, 'grade', e.target.value)} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor={`child-note-${idx}`}>특이사항</Label>
+                <Textarea id={`child-note-${idx}`} value={child.note} onChange={(e) => handleChildChange(idx, 'note', e.target.value)} />
+              </div>
+            </div>
+          ))}
+          <Button type="button" variant="outline" onClick={handleAddChild}>자녀 추가</Button>
+        </div>
+        <Button type="submit" className="w-full" disabled={loading}>
+          {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          회원가입
+        </Button>
+        <p className="text-sm text-center">
+          이미 계정이 있으신가요?{' '}
+          <Link to="/login" className="text-brand-green">로그인</Link>
+        </p>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- support email-based login alongside Kakao
- add parent signup page with child info and duplicate checks
- display login and signup buttons on homepage header and mobile menu

## Testing
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm test` (backend) *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68968403d21883238766c4ae8dba483e