### PR TITLE
Halve font size for mobile views

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -59,3 +59,11 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  @media (max-width: 768px) {
+    html {
+      font-size: 50%;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Halve overall font size on screens narrower than 768px for better mobile layout

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_6897068deb20832396e0b4c89f5dd0e3