### PR TITLE
fix: prefill child info when editing

### DIFF
--- a/frontend/src/pages/admin/MemberManagementPage.jsx
+++ b/frontend/src/pages/admin/MemberManagementPage.jsx
@@ -65,6 +65,12 @@ const ChildFormModal = ({ child, onSave, onCancel }) => {
     const [name, setName] = useState(child?.name || '');
     const [grade, setGrade] = useState(child?.grade || '');
     const [team, setTeam] = useState(child?.team || '');
+    // 자녀 정보가 변경될 때마다 입력 폼을 최신 값으로 동기화합니다.
+    useEffect(() => {
+        setName(child?.name || '');
+        setGrade(child?.grade || '');
+        setTeam(child?.team || '');
+    }, [child]);
     const [isSaving, setIsSaving] = useState(false);
 
     const handleSubmit = async () => {


### PR DESCRIPTION
## Summary
- ensure child edit modal pre-fills name, grade, and team

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689708ba07c08323b3de6858c5a27910