### PR TITLE
Fix Kakao login by loading v1 SDK

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,7 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Soccer Academy</title>
     
-    <script src="https://t1.kakaocdn.net/kakao_js_sdk/2.7.1/kakao.min.js" crossorigin="anonymous"></script>
+    <!-- Kakao JavaScript SDK v1 for login with access token support -->
+    <script src="https://developers.kakao.com/sdk/js/kakao.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -15,8 +15,10 @@ export function AuthProvider({ children }) {
 
   const kakaoLogin = () => {
     return new Promise((resolve, reject) => {
-      if (!window.Kakao) return reject(new Error("Kakao SDK not loaded"));
-      
+      if (!window.Kakao || !window.Kakao.Auth || !window.Kakao.Auth.login) {
+        return reject(new Error('Kakao SDK not loaded'));
+      }
+
       window.Kakao.Auth.login({
         success: async (authObj) => {
           try {


### PR DESCRIPTION
## Summary
- Load Kakao JavaScript SDK v1 to restore `Auth.login`
- Validate Kakao SDK availability before invoking login

## Testing
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68993de1124883238587cd8c2652146b