### PR TITLE
fix: default missing kakao profile image

### DIFF
--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -45,7 +45,11 @@ export function AuthProvider({ children }) {
         kakaoId: profile.kakaoId,
         displayName: profile.displayName,
         email: profile.email,
-        profileImageUrl: profile.profileImageUrl,
+        // Firestore does not allow undefined field values. Some Kakao accounts
+        // may not include a profile image, so ensure we store an empty string
+        // instead of `undefined` to avoid setDoc throwing an error on first
+        // login.
+        profileImageUrl: profile.profileImageUrl ?? '',
         role: 'parent',
         children: [],
         createdAt: serverTimestamp(),


### PR DESCRIPTION
## Summary
- prevent Firestore error on first Kakao login by defaulting missing profile images to an empty string

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689997e9d3508323814e7a413f903431