### PR TITLE
feat: add attendance management and refresh profile

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -20,6 +20,7 @@ import AdminDashboard from './pages/admin/AdminDashboard';
 import MemberManagementPage from './pages/admin/MemberManagementPage';
 import ScheduleManagementPage from './pages/admin/ScheduleManagementPage';
 import ProgressManagementPage from './pages/admin/ProgressManagementPage'; // ⭐️ 1. import 추가
+import AttendanceManagementPage from './pages/admin/AttendanceManagementPage';
 
 export default function App() {
   return (
@@ -39,11 +40,12 @@ export default function App() {
         </Route>
         
         {/* Admin Routes */}
-        <Route path="/admin" element={<AdminLayout />}>
+        <Route path="/admin" element={<AdminLayout />}> 
             <Route index element={<AdminDashboard />} />
             <Route path="members" element={<MemberManagementPage />} />
             <Route path="schedule" element={<ScheduleManagementPage />} />
             <Route path="progress" element={<ProgressManagementPage />} /> {/* ⭐️ 2. 라우트 추가 */}
+            <Route path="attendance" element={<AttendanceManagementPage />} />
         </Route>
 
         <Route path="*" element={<Navigate to="/" />} />

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -84,11 +84,19 @@ export function AuthProvider({ children }) {
     return unsubscribe;
   }, []);
 
+  const refreshUserData = async () => {
+    if (!currentUser) return;
+    const userRef = doc(db, 'users', currentUser.uid);
+    const userSnap = await getDoc(userRef);
+    setUserData(userSnap.exists() ? userSnap.data() : null);
+  };
+
   const value = {
     currentUser,
     userData,
     kakaoLogin,
     handleKakaoRedirect,
+    refreshUserData,
     logout,
     loading,
   };

--- a/frontend/src/layouts/AdminLayout.jsx
+++ b/frontend/src/layouts/AdminLayout.jsx
@@ -2,7 +2,7 @@ import { Link, Outlet, useNavigate, useLocation } from 'react-router-dom';
 import { useState } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 import { Button } from '@/components/ui/button';
-import { Home, Users, Calendar, BarChart2, LogOut, Menu, X } from 'lucide-react';
+import { Home, Users, Calendar, BarChart2, CheckCircle, LogOut, Menu, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 export default function AdminLayout() {
@@ -23,6 +23,7 @@ export default function AdminLayout() {
     { name: '회원 관리', href: '/admin/members', icon: <Users className="w-5 h-5 mr-2" /> },
     { name: '일정 관리', href: '/admin/schedule', icon: <Calendar className="w-5 h-5 mr-2" /> },
     { name: '성과 관리', href: '/admin/progress', icon: <BarChart2 className="w-5 h-5 mr-2" /> },
+    { name: '출결 관리', href: '/admin/attendance', icon: <CheckCircle className="w-5 h-5 mr-2" /> },
   ];
 
   return (

--- a/frontend/src/pages/MyPage.jsx
+++ b/frontend/src/pages/MyPage.jsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import ProfileForm from '../components/ProfileForm';
 import {
@@ -13,8 +12,7 @@ import {
 } from '../firebaseConfig';
 
 export default function MyPage() {
-  const { currentUser, userData } = useAuth();
-  const navigate = useNavigate();
+  const { currentUser, userData, refreshUserData } = useAuth();
   const [initialData, setInitialData] = useState(null);
   const [loading, setLoading] = useState(false);
 
@@ -83,7 +81,15 @@ export default function MyPage() {
         children: childIds,
       });
 
-      navigate('/dashboard');
+      setInitialData({
+        username,
+        name,
+        contact,
+        children: children.map((c, i) => ({ ...c, id: childIds[i] })),
+      });
+
+      await refreshUserData();
+      alert('정보가 저장되었습니다.');
     } catch (err) {
       console.error(err);
     } finally {

--- a/frontend/src/pages/admin/AttendanceManagementPage.jsx
+++ b/frontend/src/pages/admin/AttendanceManagementPage.jsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react';
+import { collection, onSnapshot, doc, updateDoc } from 'firebase/firestore';
+import { db } from '../../firebaseConfig';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '@/components/ui/table';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+
+export default function AttendanceManagementPage() {
+  const [children, setChildren] = useState([]);
+
+  useEffect(() => {
+    const unsub = onSnapshot(collection(db, 'children'), (snap) => {
+      setChildren(snap.docs.map((d) => ({ id: d.id, ...d.data() })));
+    });
+    return () => unsub();
+  }, []);
+
+  const updateStatus = async (id, status) => {
+    await updateDoc(doc(db, 'children', id), { attendanceStatus: status });
+  };
+
+  return (
+    <div className="p-4 md:p-8 space-y-8">
+      <Card>
+        <CardHeader>
+          <CardTitle>출결 관리</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>이름</TableHead>
+                <TableHead>팀</TableHead>
+                <TableHead>현재 상태</TableHead>
+                <TableHead>관리</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {children.map((child) => (
+                <TableRow key={child.id}>
+                  <TableCell className="font-medium">{child.name}</TableCell>
+                  <TableCell>{child.team}</TableCell>
+                  <TableCell>
+                    <Badge>{child.attendanceStatus || '미등원'}</Badge>
+                  </TableCell>
+                  <TableCell className="space-x-2">
+                    <Button size="sm" variant="outline" onClick={() => updateStatus(child.id, '출석')}>출석</Button>
+                    <Button size="sm" variant="outline" onClick={() => updateStatus(child.id, '지각')}>지각</Button>
+                    <Button size="sm" variant="outline" onClick={() => updateStatus(child.id, '결석')}>결석</Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- refresh user data after profile updates on MyPage
- add admin attendance management page and navigation

## Testing
- `npm test` *(frontend, backend — fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68999bbb79688323b82fd149e8eda046